### PR TITLE
Refinements to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,12 @@
     "prescaffold": "cd scaffold && npm install",
     "scaffold": "node scaffold \"config/scaffold.config.js\""
   },
-  "author": "",
-  "license": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kpmg-agile/ca-pqvp.git"
+  },
+  "author": "KPMG",
+  "license": "UNLICENSED",
   "dependencies": {
     "@angular/common": "^2.0.0",
     "@angular/compiler": "^2.0.0",
@@ -59,10 +63,10 @@
     "raml-parser": "^0.8.18",
     "reflect-metadata": "^0.1.8",
     "rimraf": "^2.5.4",
-    "rxjs": "5.0.0-beta.12",
+    "rxjs": "^5.0.1",
     "serve-static": "^1.11.1",
     "uswds": "^0.14.0",
-    "zone.js": "^0.6.21"
+    "zone.js": "^0.7.2"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",
@@ -111,7 +115,7 @@
     "raw-loader": "^0.5.1",
     "sass-loader": "^4.0.0",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.2",
+    "webpack": "^2.2.0",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.2"
   }


### PR DESCRIPTION
- Populated repository and license to prevent warnings
[peer dependencies are required to be manually added to the top level package.json (since NPM v3.0)]
- @angular/core 2.4.7 peer dependencies required updated versions of rxjs and zone.js
- several packages required updated version of web pack