### PR TITLE
BUILD_INFO / git history

### DIFF
--- a/client/status/dump-git-log.sh
+++ b/client/status/dump-git-log.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+urlencode() {
+    # urlencode <string>
+    old_lc_collate=$LC_COLLATE
+    LC_COLLATE=C
+
+    local length="${#1}"
+    for (( i = 0; i < length; i++ )); do
+        local c="${1:i:1}"
+        case $c in
+            [a-zA-Z0-9.~_-]) printf "$c" ;;
+            *) printf '%%%02X' "'$c" ;;
+        esac
+    done
+
+    LC_COLLATE=$old_lc_collate
+}
+
+# BUILD_INFO = branch / commit
+export BUILD_INFO=$(git rev-parse --abbrev-ref HEAD)"  /  "$(git describe --long --dirty)
+
+# git log
+git log -n 20 --pretty=format:"%h:::%ad:::%an:::%s" | awk -f format-git-log.awk > git-log.js
+
+# git graph
+script -q /dev/null git --no-pager log -n 20 --graph | tr -d "\033" | sed  -E -f format-git-graph.sed > git-graph.js

--- a/client/status/format-git-graph.sed
+++ b/client/status/format-git-graph.sed
@@ -1,0 +1,38 @@
+# sed
+
+s/.$/\_END\_/g
+s/\_END\_/\<\/div\>\" \+/g
+s/^/\"\<div\>/g
+
+# Must split these lines to include a newline character
+1 i\
+document.write\(
+
+$a\
+\"\"\);\
+
+s/\[30m/\<b class='black1'\>/g
+s/\[31m/\<b class='red1'\>/g
+s/\[32m/\<b class='green1'\>/g
+s/\[33m/\<b class='yellow1'\>/g
+s/\[34m/\<b class='blue1'\>/g
+s/\[35m/\<b class='magenta1'\>/g
+s/\[36m/\<b class='cyan1'\>/g
+s/\[37m/\<b class='white1'\>/g
+s/\[1;30m/\<b class='black2'\>/g
+s/\[1;31m/\<b class='red2'\>/g
+s/\[1;32m/\<b class='green2'\>/g
+s/\[1;33m/\<b class='yellow2'\>/g
+s/\[1;34m/\<b class='blue2'\>/g
+s/\[1;35m/\<b class='magenta2'\>/g
+s/\[1;36m/\<b class='cyan2'\>/g
+s/\[1;37m/\<b class='white2'\>/g
+
+s/\[m/\<\/b\>/g
+
+s/\*/\<i class='node'\>\*\<\/i\>/g
+s/\\/\<i class='fork'\>\\\\\<\/i\>/g
+#s/\//\<i class='fork'\>\/\/\<\/i\>/g
+s/\|/<i\>\|\<\/i\>/g
+
+

--- a/client/status/format-git-log.awk
+++ b/client/status/format-git-log.awk
@@ -1,0 +1,35 @@
+#!/usr/bin/awk
+
+function escape(str, c, len, res) {
+    len = length(str)
+    res = ""
+    for (i = 1; i <= len; i++) {
+	c = substr(str, i, 1);
+	if (c ~ /[0-9A-Za-z]/)
+	    res = res c
+	else
+	    res = res "&#x00" sprintf("%02X", ord[c]) ";"
+    }
+    return res
+}
+
+BEGIN {
+    for (i = 0; i <= 255; i++) {
+	ord[sprintf("%c", i)] = i
+    }
+    url = "https://github.com/kpmg-agile/ca-pqvp/commit/"
+
+    FS=":::"
+
+    printf "document.write('<p>BRANCH / COMMIT</p><h2>%s</h2><hr>", ENVIRON["BUILD_INFO"]
+}
+
+{
+    printf "<li><code><a href=\x22" url "%s\x22 target=\x22_blank\x22>%s</a></code><small>%s</small><person>%s</person>", $1, $1, $2, $3
+    $1=$2=$3=""
+    printf "<span>%s</span></li>", escape($0)
+}
+
+END {
+    printf "%s", "');"
+}

--- a/client/status/git.css
+++ b/client/status/git.css
@@ -1,0 +1,117 @@
+html {
+    background-color: black;
+}
+
+body {
+    font-family: "Open Sans Condensed", sans-serif;
+    color: white;
+}
+
+.history {
+    padding: 20px;
+}
+.graph {
+    padding: 20px;
+}
+
+p, h1, h2, h3, h4, h5 {
+    margin: 2px 0;
+}
+
+hr {
+    margin: 15px 0;
+}
+
+li {
+    list-style-type: none;
+    margin-bottom: 5px;
+}
+
+a, small, person, span {
+    display: inline-block;
+    vertical-align: top;
+}
+
+a {
+    width: 10%;
+}
+
+small {
+    width: 20%;
+}
+
+person {
+    width: 15%;
+}
+
+span {
+    width: 55%;
+    font-size: 12px;
+}
+
+a {
+    color: teal;
+}
+
+.graph div {
+    margin: 0px;
+    font-size: 12px;
+    height: 20px;
+}
+
+b {
+    display: inline-block;
+    padding: 0px;
+    margin: 0px 3px;
+    font-size: 12px;
+    font-weight: 300;
+}
+
+i {
+    font-style: normal;
+    font-size: 20px;
+    font-weight: 500;
+}
+
+i.node {
+    padding-left: 7px;
+    position: relative;
+    top: 7px;
+    left: -3px;
+}
+
+i.fork {
+    margin-left: -3px;
+}
+
+.red1 {
+    color: red;
+}
+
+.green1 {
+    color: green;
+}
+
+.yellow1 {
+    color: yellow;
+}
+
+.blue1 {
+    color: blue;
+}
+
+.red2 {
+    color: red;
+}
+
+.green2 {
+    color: green;
+}
+
+.yellow2 {
+    color: yellow;
+}
+
+.blue2 {
+    color: blue;
+}

--- a/client/status/index.html
+++ b/client/status/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>CalProc Application Status</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,500,700" rel="stylesheet">
+    <link href="git.css" rel="stylesheet">
+</head>
+<body>
+<div class="history">
+    <script src="git-log.js" type="application/javascript"></script>
+</div>
+<div class="graph">
+    <script src="git-graph.js" type="application/javascript"></script>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- BUILD_INFO set to branch / commit
- git log generates history and graph view, saves to .js
- ./client/status/index.html imports log and graph

@robertlevy Give this a spin. The script and html is isolated from the app and not reliant on any javascript libraries. i.e. the page should still show if the app has crashed. 
dump-git-log.sh to generate the files
./client/status/index.html to view 