### PR TITLE
GET query overhaul

### DIFF
--- a/server/api.v1.js
+++ b/server/api.v1.js
@@ -194,7 +194,7 @@ router.get('/api/v1/products/:product', function (req, res) {
 router.get('/api/v1/images/:image', function (req, res) {
 
     let query = 'MATCH (image: Image) where ID(image)={imageid} RETURN image;';
-    let params = { imageid: parseInt(req.params.image,10) };
+    let params = { imageid: parseInt(req.params.image, 10) };
     getQuery(query, params, res, true, image => image.properties );
 });
 
@@ -418,7 +418,7 @@ function authenticate(req, res, query, params) {
 function getQuery(query, params, res, singleEntity, mapper) {
 
     // default to the identity function
-    mapper = mapper || function (x) {return x; };
+    mapper = mapper || function (x) { return x; };
 
     let tx = db.beginTransaction();
         db.cypher({ query, params }, function callback(err, results) {


### PR DESCRIPTION
overhaul to the getQuery helper function.  it now takes these parameters:

- neo4j query string
- query parameters object
- res object (getQuery will not handle sending the HTTP response)
- singleEntity boolean indicating whether the query is expected to return an array or a single object
- mapper function that each 'row' returned from the DB is sent through.  this gives us the chance to do transofmrations before returning data to the UI 

updated `GET /users`, `GET /products`, `GET /products/:productId`, `GET /products/popular`, and `GET /images/:imageId` based on this.  these are the services the UI is most dependent on right now.

commented out all other services so that the mocks will be triggered until we can get them updated.  will need to set up a similar pattern for post/put/delete requests.