### PR TITLE
Update production-stack.yml

### DIFF
--- a/docker/production-stack.yml
+++ b/docker/production-stack.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   web:
-    image: 'localhost:5000/webstart'
+    image: 'webstart:3'
     ports:
       - '8080:8080'
     networks:


### PR DESCRIPTION
Since docker pull is incredibly buggy and abyssal performance, restructuring how we deploy on Jenkins.  This change supports that.

Jenkins DEV deploy will fail until this is merged.