### PR TITLE
No longer using the i18next language property when determining the cu…

### DIFF
--- a/client/shared/directives/language-selector/LanguageSelector.js
+++ b/client/shared/directives/language-selector/LanguageSelector.js
@@ -3,6 +3,7 @@ import i18next from 'i18next';
 import $ from 'jquery';
 import template from './LanguageSelector.html';
 import styles from './LanguageSelector.scss';
+import config from '../../../../config/app.config';
 
 @Component({
     selector: 'language-selector',
@@ -37,10 +38,15 @@ export default class LanguageSelector {
 
     ngOnInit() {
         this.determineCurrentLanguage();
+
+        i18next.on('languageChanged', () => {
+            this.determineCurrentLanguage();
+            this.onLanguageChanged(i18next.language);
+        });
     }
 
     determineCurrentLanguage() {
-        let currentLocale = localStorage.getItem('i18nextLng');
+        let currentLocale = i18next.language || config.defaultLangCode;
         let optionLocale = this.languageOptions.filter(language => language.locale === currentLocale);
 
         if (optionLocale && optionLocale.length) {
@@ -49,7 +55,6 @@ export default class LanguageSelector {
         } else {
             // if there is no current locale set in i18next, set it to the first in our predetermined locale set
             this.selectedLanguage = this.languageOptions[0].locale;
-            this.onLanguageChanged(this.selectedLanguage);
         }
     }
 


### PR DESCRIPTION
…rrent language setting in the language selector during init.  It seems to not be reliable.  Instead now using the value in local storage that represents the same data.

Resolves #235 